### PR TITLE
Workaround FTBFS in minimal chroot

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,7 @@
+if RUBY_VERSION >= '1.9'
+	Encoding.default_external = Encoding::UTF_8
+	Encoding.default_internal = Encoding::UTF_8
+end
 require_relative 'version'
 require 'paint'
 require 'set'


### PR DESCRIPTION
Building itsalltext currently fails with Ruby 1.9 and 2.0 with the following error:

rake aborted!
invalid byte sequence in US-ASCII
…/Rakefile:51:in `block in load_dtd_entities'
…/Rakefile:50:in`map'
…/Rakefile:50:in `load_dtd_entities'
…/Rakefile:56:in`find_dtd_errors'
…/Rakefile:103:in `block in diff_locale'
…/Rakefile:94:in`each'
…/Rakefile:94:in `diff_locale'
…/Rakefile:41:in`block (2 levels) in <top (required)>'
…/Rakefile:41:in `each'
…/Rakefile:41:in`block in <top (required)>'

Bug-Debian: https://bugs.debian.org/739774
