### PR TITLE
Include the full path part of the URL in a file name.

### DIFF
--- a/src/chrome/content/cacheobj.js
+++ b/src/chrome/content/cacheobj.js
@@ -27,7 +27,7 @@ function CacheObj(node) {
     var that = this,
     hitch_re = /^hitched_/,
     doc = node.ownerDocument,
-    host,
+    basename,
     hash,
     method,
     extension;
@@ -79,7 +79,6 @@ function CacheObj(node) {
     /* Figure out where we will store the file.  While the filename can
      * change, the directory that the file is stored in should not!
      */
-    host = window.escape(doc.location.hostname);
     hash = itsalltext.hashString(
         [ doc.location.protocol,
             doc.location.port,
@@ -87,7 +86,8 @@ function CacheObj(node) {
             doc.location.pathname,
             that.node_id].join(':')
     );
-    that.base_filename = [host, hash.slice(0, 10)].join('.');
+    basename = window.encodeURIComponent(doc.location.host + doc.location.pathname);
+    that.base_filename = [basename, hash.slice(0, 10)].join('.');
     /* The current extension.
      * @type String
      */

--- a/src/chrome/content/cacheobj.js
+++ b/src/chrome/content/cacheobj.js
@@ -103,8 +103,11 @@ function CacheObj(node) {
                     continue;
                 }
                 break;
+              case 'NS_ERROR_FILE_TARGET_DOES_NOT_EXIST':
+                break;
+              default:
+                throw e;
             }
-            throw e;
         }
         break;
     }

--- a/src/chrome/content/cacheobj.js
+++ b/src/chrome/content/cacheobj.js
@@ -27,7 +27,7 @@ function CacheObj(node) {
     var that = this,
     hitch_re = /^hitched_/,
     doc = node.ownerDocument,
-    basename,
+    urlname,
     hash,
     method,
     extension;
@@ -85,9 +85,30 @@ function CacheObj(node) {
             doc.location.search ? doc.location.search : '?',
             doc.location.pathname,
             that.node_id].join(':')
-    );
-    basename = window.encodeURIComponent(doc.location.host + doc.location.pathname);
-    that.base_filename = [basename, hash.slice(0, 10)].join('.');
+    ).slice(0, 10);
+
+    /* Determine the local filename for the document. */
+    for (urlname = doc.location.host + doc.location.pathname; ;) {
+        that.base_filename = [window.encodeURIComponent(urlname), hash].join('.');
+        try {
+            // Hope isWritable() would work here, but it throws
+            // NS_ERROR_FILE_TARGET_DOES_NOT_EXIST if the file is
+            // nonexistent.
+            this.getFile().isFile();
+        } catch (e) {
+            switch (e.name) {
+              case 'NS_ERROR_FILE_NAME_TOO_LONG':
+                if (urlname.length > 0) {
+                    urlname = urlname.slice(0, -1);
+                    continue;
+                }
+                break;
+            }
+            throw e;
+        }
+        break;
+    }
+
     /* The current extension.
      * @type String
      */


### PR DESCRIPTION
A host part is sometimes not enough to guess a proper major mode for editing the text.

With this patch, you can, for example, configure your text editor to set its editing mode for Wiki markup if the file name has /wiki/ (actually escaped as "%2Fwiki%2F") in it.