### PR TITLE
Dispatch an "input" event on update

### DIFF
--- a/src/chrome/content/cacheobj.js
+++ b/src/chrome/content/cacheobj.js
@@ -582,6 +582,10 @@ CacheObj.prototype.update = function () {
             var event = this.node.ownerDocument.createEvent("HTMLEvents");
             event.initEvent('change', true, false);
             this.node.dispatchEvent(event);
+            
+            var inputEvent = this.node.ownerDocument.createEvent("HTMLEvents");
+            inputEvent.initEvent('input', true, false);
+            this.node.dispatchEvent(inputEvent);
 
             return true;
         }


### PR DESCRIPTION
If a listener is interested in immediate changes, the "input" event is more relevant than the "change" event.