### PR TITLE
Fix bug #44: IAT automatically overwrites the textarea in the browser with the value it has stored previously on disk

### DIFF
--- a/src/chrome/content/cacheobj.js
+++ b/src/chrome/content/cacheobj.js
@@ -188,10 +188,11 @@ CacheObj.prototype.setExtension = function (ext) {
         return; /* It's already set.  No problem. */
     }
 
+    this.extension = ext;
+
     /* Create the nsIFile object */
     var file = this.getFile();
 
-    this.extension = ext;
     if (file.exists()) {
         this.timestamp = file.lastModifiedTime;
         this.size      = file.fileSize;


### PR DESCRIPTION
Fix bug #44: IAT automatically overwrites the textarea in the browser with the value it has stored previously on disk

Set found extension **before** instantiating the file object. Otherwise, the default extension will be used for the file.