### PR TITLE
Really recover last used file when more than one previous file exist

### DIFF
--- a/src/chrome/content/cacheobj.js
+++ b/src/chrome/content/cacheobj.js
@@ -273,6 +273,8 @@ CacheObj.prototype.initFromExistingFile = function () {
     fobj = itsalltext.factoryFile(itsalltext.getWorkingDir()),
     entries,
     ext = null,
+    last_mtime = 0,
+    prev_found = null,
     tmpfiles = /(\.bak|.tmp|~)$/,
     entry;
     if (fobj.exists() && fobj.isDirectory()) {
@@ -282,14 +284,18 @@ CacheObj.prototype.initFromExistingFile = function () {
             entry.QueryInterface(Components.interfaces.nsIFile);
             if (entry.leafName.indexOf(base) === 0) {
                 // startswith
-                if (ext === null && !entry.leafName.match(tmpfiles)) {
+                if (entry.lastModifiedTime > last_mtime && !entry.leafName.match(tmpfiles)) {
+                    if (prev_found !== null) {
+                        try {
+                            prev_found.remove(false);
+                        } catch (e) {
+                            //disabled-debug -- itsalltext.debug('unable to remove', entry, 'because:', e);
+                        }
+                    }
                     ext = entry.leafName.slice(base.length);
+                    last_mtime = entry.lastModifiedTime;
+                    prev_found = entry;
                     continue;
-                }
-                try {
-                    entry.remove(false);
-                } catch (e) {
-                    //disabled-debug -- itsalltext.debug('unable to remove', entry, 'because:', e);
                 }
             }
         }


### PR DESCRIPTION
When fixing #44, I saw this other issue/feature.

In `initFromExistingFile()`, the first file with the same base is picked and its extension used. If you have previously modified with other extension (by accident, or else), the first one that comes from the file system is the one picked. With this patch the **really** last modified file is picked. All other (older) versions are removed, like before.