### PR TITLE
Update homepage URL (as displayed in `about:addons`).

### DIFF
--- a/src/install.rdf
+++ b/src/install.rdf
@@ -20,7 +20,7 @@
 
     <em:name>It's All Text!</em:name>
     <em:description>Edit text using your favorite editor!</em:description>
-    <em:homepageURL>http://addons.mozilla.org/firefox/4125</em:homepageURL>
+    <em:homepageURL>https://addons.mozilla.org/en-US/firefox/addon/its-all-text/</em:homepageURL>
     <em:optionsURL>chrome://itsalltext/content/preferences.xul</em:optionsURL>
     <em:iconURL>chrome://itsalltext/content/icon.png</em:iconURL>
     <em:aboutURL>chrome://itsalltext/content/about.xul</em:aboutURL>

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,7 +10,7 @@
     <h1>It's All Text! tests</h1>
 
     <p>
-      These are a series of tests for verifying that <a href="http://addons.mozilla.org/firefox/4125">It's All Text!</a> is working correctly.  I'll be adding more tests to these pages as I discover bugs.
+      These are a series of tests for verifying that <a href="https://addons.mozilla.org/en-US/firefox/addon/its-all-text/">It's All Text!</a> is working correctly.  I'll be adding more tests to these pages as I discover bugs.
     </p>
 
     <p>


### PR DESCRIPTION
Hi Christian,

I noticed that an old URL (that now results in a 404 on AMO) is listed as the
homepage for Its All Text when viewed in <about:addons>. Here’s a small fix to
update the two references to the old URL that I found in the repository.

Regards,
Anthony